### PR TITLE
fixing default build configuration

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -211,8 +211,8 @@ set(SRC "${CMAKE_SOURCE_DIR}/src")
         ${SRC}/partSystem.h
         ${SRC}/emitter.cpp
         ${SRC}/emitter.h
-        ${SRC}/mmFBO.cpp
-        ${SRC}/mmFBO.h
+        ${SRC}/tools/mmFBO.cpp
+        ${SRC}/tools/mmFBO.h
         ${SRC}/palettes.cpp
         ${SRC}/palettes.h
         ${SRC}/ParticlesUtils.cpp
@@ -396,7 +396,7 @@ add_executable(${PROJECT_NAME}
 # GLFW package - default search for already installed
 #
 #       to use internal GLFW set TRUE
-set(GLAPP_USE_INTERNAL_GLFW FALSE)
+set(GLAPP_USE_INTERNAL_GLFW TRUE)
 if(${GLAPP_USE_INTERNAL_GLFW})
     target_include_directories(${PROJECT_NAME} PUBLIC ${SRC}/libs/glfw/include)
 


### PR DESCRIPTION
To allow new users to easily build your source, I wanted to add these changes. I think you moved the mmFBO files into the tools folder without changing the build CMakeLists.txt file, and the glfw build scripts don't work by default on my Linux machine, and I expect it will be the same on many others, so I just changed the "Use internal GLFW" GLAPP_USE_INTERNAL_GLFW option to TRUE so it is enabled by default. It will be easier for everyone